### PR TITLE
Specify version of ldap3 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     description="An LDAP3 auth provider for Synapse",
     install_requires=[
         "Twisted>=15.1.0",
-        "ldap3",
+        "ldap3>=0.9.5",
         "service_identity",
     ],
     long_description=read_file(("README.rst",)),


### PR DESCRIPTION
`LdapAuthProvider` relies on `ldap3` parsing the URI for e.g. port and ldaps, but this was only implemented in version 0.9.5 (see also matrix-org/package-synapse-debian#11)