### PR TITLE
Fix Format Specifiers in Logging Call

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -198,7 +198,7 @@ class LdapAuthProvider(object):
 
                     logger.info(
                         "Registration based on LDAP data was successful: "
-                        "%d: %s (%s, %)",
+                        "%s: %s (%s, %s)",
                         user_id, localpart, name, mail
                     )
 


### PR DESCRIPTION
I believe this should fix #38, but I haven't been able to test it just yet.