### PR TITLE
fix string formatting for ldap registration message

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -198,7 +198,7 @@ class LdapAuthProvider(object):
 
                     logger.info(
                         "Registration based on LDAP data was successful: "
-                        "%d: %s (%s, %)",
+                        "%s: %s (%s, %s)",
                         user_id, localpart, name, mail
                     )
 


### PR DESCRIPTION
Otherwise, errors will show up:

```
2018-04-16 18:15:47,458 - twisted - 131 - ERROR - POST-0- Traceback (most recent call last):
2018-04-16 18:15:47,458 - twisted - 131 - ERROR - POST-0-   File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
2018-04-16 18:15:47,458 - twisted - 131 - ERROR - POST-0-     msg = self.format(record)
2018-04-16 18:15:47,458 - twisted - 131 - ERROR - POST-0-   File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
2018-04-16 18:15:47,459 - twisted - 131 - ERROR - POST-0-     return fmt.format(record)
2018-04-16 18:15:47,459 - twisted - 131 - ERROR - POST-0-   File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
2018-04-16 18:15:47,459 - twisted - 131 - ERROR - POST-0-     record.message = record.getMessage()
2018-04-16 18:15:47,460 - twisted - 131 - ERROR - POST-0-   File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
2018-04-16 18:15:47,460 - twisted - 131 - ERROR - POST-0-     msg = msg % self.args
2018-04-16 18:15:47,460 - twisted - 131 - ERROR - POST-0- TypeError: %d format: a number is required, not str
2018-04-16 18:15:47,460 - twisted - 131 - ERROR - POST-0- Logged from file ldap_auth_provider.py, line 202
```