### PR TITLE
Need to catch IndexError as well when parsing the mail attribute from LDAP

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -185,7 +185,7 @@ class LdapAuthProvider(object):
                     name = attrs[self.ldap_attributes['name']][0]
                     try:
                         mail = attrs[self.ldap_attributes['mail']][0]
-                    except KeyError:
+                    except IndexError, KeyError:
                         mail = None
 
                     # create account


### PR DESCRIPTION
This allows new users who have LDAP credentials (and no email set) but no matrix credentials to perform a first-time login.