### PR TITLE
Update LDAP dependency to fix broken unittests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     description="An LDAP3 auth provider for Synapse",
     install_requires=[
         "Twisted>=15.1.0",
-        "ldap3>=0.9.5",
+        "ldap3>=2.6",
         "service_identity",
     ],
     long_description=read_file(("README.rst",)),


### PR DESCRIPTION
There was a breakage with the old version of LDAP3 we were using. Update to fix.

Details: https://github.com/cannatag/ldap3/issues/474