### PR TITLE
Check Synapse version before binding email

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setup(
         "ldap3>=2.6",
         "service_identity",
     ],
+    test_require=[
+        "matrix-synapse",
+    ],
     long_description=read_file(("README.rst",)),
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     Twisted>=15.1
     mock
     ldaptor
+    matrix-synapse
     ldap0: ldap3<1.0
     ldap1: ldap3>=1.0,<2.0
     ldap2: ldap3>=2.0


### PR DESCRIPTION
Old Synapse versions (0.99.3 and earlier) did not support having emails bound by password providers, and as such cause errors with the current ldap3 password provider, which expects this functionality.

This change first checks the running Synapse version, and only binds emails if a version of Synapse > 0.99.3 is running.

The only issue now though is if someone is running off the current Synapse develop. That means they'll have the ability to bind emails, but since 0.99.4/1.0.0 hasn't been tagged yet, they're still marketing themselves as 0.99.3. So emails will not be bound. This isn't a game-breaking issue, but adding emails afterwards can be a pain. To this end, we should warn people that they should not run the version of matrix-synapse-ldap3 with this PR, and Synapse /develop before 0.99.4/1.0.0 is tagged, unless they don't care about emails not being bound to their account on signup.