### PR TITLE
Add tests for search mode and add coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+comment: off
+
+coverage:
+  status:
+    project:
+      default:
+        target: 0  # Target % coverage, can be auto. Turned off for now
+        threshold: null
+        base: auto
+    patch:
+      default:
+        target: 0
+        threshold: null
+        base: auto

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+
+[run]
+branch = True
+include = ldap_auth_provider.py
+
+[report]
+precision = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-.coverage
-.tox/
+/.coverage
+/.tox/
 __pycache__/
 *.egg-info/
 *.pyc
-build/
-dist/
-_trial_temp/
-htmlcov/
+/build/
+/dist/
+/_trial_temp/
+/htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 build/
 dist/
 _trial_temp/
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 env:
 - TOXENV=packaging
 - TOXENV=pep8
-- TOXENV=py27-ldap0
-- TOXENV=py27-ldap1
-- TOXENV=py27-ldap2
+- TOXENV=py27-ldap0,codecov
+- TOXENV=py27-ldap1,codecov
+- TOXENV=py27-ldap2,codecov
 
 install:
 - pip install tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include *.py
 include LICENSE
 include tox.ini
 include requirements.txt
+include .coveragerc
 recursive-include tests *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include LICENSE
 include tox.ini
 include requirements.txt
 include .coveragerc
+include .codecov.yml
 recursive-include tests *.py

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -497,11 +497,11 @@ class LdapAuthProvider(object):
                 # Note: do not use rebind(), for some reason it did not verify
                 #       the password for me!
                 yield threads.deferToThread(conn.unbind)
-                result, _ = yield self._ldap_simple_bind(
+                result, conn = yield self._ldap_simple_bind(
                     server=server, bind_dn=user_dn, password=password
                 )
 
-                defer.returnValue((result, None, responses[0]))
+                defer.returnValue((result, conn, responses[0]))
             else:
                 # BAD: found 0 or > 1 results, abort!
                 if len(responses) == 0:

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -37,7 +37,7 @@ try:
         LDAP_AUTH_SIMPLE = ldap3.AUTH_SIMPLE
     except AttributeError:
         LDAP_AUTH_SIMPLE = ldap3.SIMPLE
-except ImportError:
+except ImportError:  # pragma: no cover
     ldap3 = None
     pass
 
@@ -58,7 +58,7 @@ class LdapAuthProvider(object):
     def __init__(self, config, account_handler):
         self.account_handler = account_handler
 
-        if not ldap3:
+        if not ldap3:  # pragma: no cover
             raise RuntimeError(
                 'Missing ldap3 library. '
                 'This is required for LDAP Authentication.'
@@ -124,7 +124,7 @@ class LdapAuthProvider(object):
                 )
                 if not result:
                     defer.returnValue(False)
-            else:
+            else:  # pragma: no cover
                 raise RuntimeError(
                     'Invalid LDAP mode specified: {mode}'.format(
                         mode=self.ldap_mode
@@ -136,7 +136,7 @@ class LdapAuthProvider(object):
                     "User authenticated against LDAP server: %s",
                     conn
                 )
-            except NameError:
+            except NameError:  # pragma: no cover
                 logger.warning(
                     "Authentication method yielded no LDAP connection, "
                     "aborting!"

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -410,7 +410,8 @@ class LdapAuthProvider(object):
             Deferred[tuple[bool, LDAP3Connection, response]]: Returns a 3-tuple
             where first field is whether a *single* entry was found, the second
             is the open connection bound to the found user and the final field
-            is the LDAP entry of the found entry.
+            is the LDAP entry of the found entry. If first field is False then
+            second and third field will both be None.
         """
 
         try:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -50,45 +50,23 @@ class LdapSimpleTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_unknown_user(self):
-        server = yield create_ldap_server()
-        with server:
-            account_handler = Mock(spec_set=[])
-            provider = create_auth_provider(server, account_handler)
-
-            result = yield provider.check_password("@non_existent:test", "password")
-            self.assertFalse(result)
+        result = yield self.auth_provider.check_password("@non_existent:test", "password")
+        self.assertFalse(result)
 
     @defer.inlineCallbacks
     def test_incorrect_pwd(self):
-        server = yield create_ldap_server()
-        with server:
-            account_handler = Mock(spec_set=[])
-            provider = create_auth_provider(server, account_handler)
-
-            result = yield provider.check_password("@bob:test", "wrong_password")
-            self.assertFalse(result)
+        result = yield self.auth_provider.check_password("@bob:test", "wrong_password")
+        self.assertFalse(result)
 
     @defer.inlineCallbacks
     def test_correct_pwd(self):
-        server = yield create_ldap_server()
-        with server:
-            account_handler = Mock(spec_set=["check_user_exists"])
-            account_handler.check_user_exists.return_value = True
-            provider = create_auth_provider(server, account_handler)
-
-            result = yield provider.check_password("@bob:test", "secret")
-            self.assertTrue(result)
+        result = yield self.auth_provider.check_password("@bob:test", "secret")
+        self.assertTrue(result)
 
     @defer.inlineCallbacks
     def test_no_pwd(self):
-        server = yield create_ldap_server()
-        with server:
-            account_handler = Mock(spec_set=["check_user_exists"])
-            account_handler.check_user_exists.return_value = True
-            provider = create_auth_provider(server, account_handler)
-
-            result = yield provider.check_password("@bob:test", "")
-            self.assertFalse(result)
+        result = yield self.auth_provider.check_password("@bob:test", "")
+        self.assertFalse(result)
 
 
 class LdapSearchTestCase(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     mock
     ldaptor
     matrix-synapse
+    coverage
     ldap0: ldap3<1.0
     ldap1: ldap3>=1.0,<2.0
     ldap2: ldap3>=2.0
@@ -14,7 +15,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE = no_byte_code
     PYTHONPATH = .
 commands =
-    trial tests
+    {envbindir}/coverage run {envbindir}/trial tests
 
 [testenv:packaging]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ deps =
     flake8
 commands = flake8 .
 
+# This uploads any coverage information that has been produced to codecov. This
+# is really only useful for CI.
 [testenv:codecov]
 passenv = CODECOV_TOKEN
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -29,3 +29,13 @@ basepython = python2.7
 deps =
     flake8
 commands = flake8 .
+
+[testenv:codecov]
+passenv = CODECOV_TOKEN
+skip_install = True
+deps =
+    coverage
+    codecov
+commands =
+    coverage xml
+    codecov -X gcov


### PR DESCRIPTION
This also includes some changes to the module:

1. Always specify attributes when searching, otherwise some servers (namely ldaptor used for unit tests) refuse to return any results even if there were matches.
2. Make `_ldap_authenticated_search` return the correct connection object so that it gets correctly closed.