### PR TITLE
Add option to create usernames from email-id's local part

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,19 @@ in search mode is provided below:
         bind_password: "ch33kym0nk3y"
         #filter: "(objectClass=posixAccount)"
 
+If you want to use the local part of email-id as username in synapse.
+configure 
+
+.. code:: yaml
+
+   attributes:
+     uid: "email"
+     mail: "email"
+     name: "givenName"
+
+for eg:email = ``local_part@domain.com`` then userid on matrix will be
+``@local_part:matrix.com``.
+
 Troubleshooting and Debugging
 -----------------------------
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -265,6 +265,13 @@ class LdapAuthProvider(object):
         Returns:
             user_id (str): User ID of the newly registered user.
         """
+        if self.ldap_attributes["uid"] == self.ldap_attributes["mail"]:
+            localpart = localpart.split('@')[0]
+            logger.info(
+                "Created username \"%s\" from email",
+                localpart,
+            )
+
         # Get full user id from localpart
         user_id = self.account_handler.get_qualified_user_id(localpart)
 


### PR DESCRIPTION
add option to user local part from email-id as username in synapse.

will help organizations using synapse to login using email-id's and 
create same usernames on synapse 
