### PR TITLE
Allow non-anonymous searches using a specific bind pattern.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Example synapse config:
            name: "givenName"
         #bind_dn:
         #bind_password:
+        #bind_pattern:
         #filter: "(objectClass=posixAccount)"
 
 If you would like to enable login/registration via email, or givenName/email
@@ -56,6 +57,8 @@ in search mode is provided below:
         bind_dn: "cn=hacker,ou=svcaccts,dc=example,dc=com"
         bind_password: "ch33kym0nk3y"
         #filter: "(objectClass=posixAccount)"
+        # Alternatively, simple binding with a custom bind pattern:
+        #bind_pattern: "WORKGROUP\\%s"
 
 Troubleshooting and Debugging
 -----------------------------

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -69,6 +69,7 @@ class LdapAuthProvider(object):
         self.ldap_start_tls = config.start_tls
         self.ldap_base = config.base
         self.ldap_attributes = config.attributes
+        self.ldap_bind_pattern = config.bind_pattern
         if self.ldap_mode == LDAPMode.SEARCH:
             self.ldap_bind_dn = config.bind_dn
             self.ldap_bind_password = config.bind_password
@@ -95,11 +96,14 @@ class LdapAuthProvider(object):
             )
 
             if self.ldap_mode == LDAPMode.SIMPLE:
-                bind_dn = "{prop}={value},{base}".format(
-                    prop=self.ldap_attributes['uid'],
-                    value=localpart,
-                    base=self.ldap_base
-                )
+                if self.ldap_bind_pattern:
+                    bind_dn = self.ldap_bind_pattern.replace("%s", localpart)
+                else:
+                    bind_dn = "{prop}={value},{base}".format(
+                        prop=self.ldap_attributes['uid'],
+                        value=localpart,
+                        base=self.ldap_base
+                    )
                 result, conn = yield self._ldap_simple_bind(
                     server=server, bind_dn=bind_dn, password=password
                 )
@@ -321,9 +325,11 @@ class LdapAuthProvider(object):
         ldap_config.start_tls = config.get("start_tls", False)
         ldap_config.base = config["base"]
         ldap_config.attributes = config["attributes"]
+        ldap_config.bind_pattern = config.get("bind_pattern", None)
 
         if "bind_dn" in config:
             ldap_config.mode = LDAPMode.SEARCH
+
             _require_keys(config, [
                 "bind_dn",
                 "bind_password",


### PR DESCRIPTION
Sometimes the LDAP login differs from the actual username. For instance, an Active
Directory server may recognize logins with the `"WORKGROUP\"` prefix. This option is
similar to Apache’s `AuthLDAPInitialBindPattern` directive.