### PR TITLE
Mark matrix-synapse-ldap3 as python3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
     ],
 )


### PR DESCRIPTION
This package is python3 compatible, so mark it as such. [Classifiers](https://pypi.org/classifiers/) are essentially just filters for pypi. Marked as python3 only as that's what [matrix-synapse](https://pypi.org/classifiers/) is marked as.