### PR TITLE
Add release documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include requirements.txt
 include .coveragerc
 include .codecov.yml
 recursive-include tests *.py
+recursive-include docs *.md

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -2,7 +2,7 @@
 
 Releasing `matrix-synapse-ldap3` involves bumping the version number, creating
 a new tag on Github, then uploading release packages to
-[PyPi](https://pypi.org) and Matrix.org's debian repos.
+[PyPi](https://pypi.org).
 
 You will need push access to this repo as well as an account on PyPi with push
 access to the
@@ -29,7 +29,3 @@ Ensure you have access to the `twine` command.
 
 1. `twine upload dist/matrix-synapse-ldap3-X.Y.Z.tar.gz` to upload the package
    to PyPi.
-
-## Uploading debian packages
-
-TODO

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -27,7 +27,8 @@ Ensure you have access to the `twine` command.
 
 1. Run `python setup.py sdist` to build the package
 
-1. `twine upload dist/matrix-synapse-ldap3-X.Y.Z.tar.gz` to upload the package to PyPi.
+1. `twine upload dist/matrix-synapse-ldap3-X.Y.Z.tar.gz` to upload the package
+   to PyPi.
 
 ## Uploading debian packages
 

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -1,0 +1,34 @@
+# How to release `matrix-synapse-ldap3`
+
+Releasing `matrix-synapse-ldap3` involves bumping the version number, creating
+a new tag on Github, then uploading release packages to
+[PyPi](https://pypi.org) and Matrix.org's debian repos.
+
+You will need push access to this repo as well as an account on PyPi with push
+access to the
+[matrix-synapse-ldap3](https://pypi.org/project/matrix-synapse-ldap3/) package.
+
+## Git repository
+
+1. Edit the `__version__` variable of `ldap_auth_provider.py` to the new release
+version. This repository uses [Semantic Versioning](https://semver.org/).
+
+1. Commit and push with the commit message `X.Y.Z`.
+
+1. Create a git tag with `git tag -s vX.Y.Z`. Set the first line of the message
+   to `vX.Y.Z`, and the rest to the changes since the last release (looking at
+   the commit history can help).
+
+1. Push the tag with `git push origin tag vX.Y.Z`
+
+## Uploading to PyPi
+
+Ensure you have access to the `twine` command.
+
+1. Run `python setup.py sdist` to build the package
+
+1. `twine upload dist/matrix-synapse-ldap3-X.Y.Z.tar.gz` to upload the package to PyPi.
+
+## Uploading debian packages
+
+TODO


### PR DESCRIPTION
Add documentation on how to release matrix-synapse-ldap3 to the repo.

**Note:** Debian packages are still marked as TODO. If someone could give me pointers there, that would be appreciated.