### PR TITLE
Support for Active Directory multidomain forest.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,9 @@ With this configuration the user can log in with either ``main.example.com\someu
 Users of other domains in the ``example.com`` forest can log in with ``domain\login``
 or ``login/domain``.
 
+Please note that ``userPrincipalName`` or similary looking LDAP attribute in the format
+``login@domain`` must be used when ``active_directory`` option is enabled.
+
 Troubleshooting and Debugging
 -----------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -80,12 +80,18 @@ in search mode is provided below:
         bind_password: "ch33kym0nk3y"
         #filter: "(objectClass=posixAccount)"
 
-Active Directory forest accounts are also supported with custom
-separator (`=` or `/`) in the following form: `login<separator>domain`.
+Active Directory forest support
+-------------------------------
 
-Please note that common domain separators `@` and `\\` can not be used in Matrix
-User Indentifiers (https://matrix.org/docs/spec/appendices#user-identifiers)
-and `/` separator is used by default.
+If the ``active_directory`` flag is set to ``true``, an Active Directory forest will be
+searched for the login details.
+In this mode, the user enters their login details in one of the forms:
+- ``<login>/<domain>``
+- ``<domain>\<login>``
+
+Despite of entered login it will be mapped to Matrix UID ``<login>/<domain>`` (The 
+normal domain separators, ``@`` and ``\\``, cannot be used in Matrix User Identifiers, so 
+``/`` is used instead).
 
 Let's say you have several domains in example.com forest:
 
@@ -99,12 +105,10 @@ Let's say you have several domains in example.com forest:
         uri: "ldap://main.example.com:389"
         base: "dc=example,dc=com"
         # Must be true for this feature to work
-        ad_forest: true
+        active_directory: true
         # Optional. Users from this domain may login
         # without specifying domain part
         default_domain: main.example.com
-        # Optional. Default /
-        mxid_domain_separator: /
         attributes:
            # This must be set to userPrincipalName
            # when ad_forest is true
@@ -115,14 +119,11 @@ Let's say you have several domains in example.com forest:
         bind_password: "ch33kym0nk3y"
         filter: "(objectClass=user)"
 
-With this configuration you can use logins:
+With this configuration the user can log in with either ``main.example.com\someuser``,
+``someuser/main.example.com`` or ``someuser``.
 
-- `someuser/main.example.com` or `someuser`
-
-  to login as `someuser` in domain `main.example.com`
-- `someuser2/second.example.com`
-
-  to login as `someuser2` in domain `second.example.com`
+Users of other domains in ``example.com`` forest can log in with ``domain\login``
+or ``login/domain``.
 
 Troubleshooting and Debugging
 -----------------------------

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,50 @@ in search mode is provided below:
         bind_password: "ch33kym0nk3y"
         #filter: "(objectClass=posixAccount)"
 
+Active Directory forest accounts are also supported with custom
+separator (`=` or `/`) in the following form: `login<separator>domain`.
+
+Please note that common domain separators `@` and `\\` can not be used in Matrix
+User Indentifiers (https://matrix.org/docs/spec/appendices#user-identifiers)
+and `/` separator is used by default.
+
+Let's say you have several domains in example.com forest:
+
+.. code:: yaml
+
+   password_providers:
+    - module: "ldap_auth_provider.LdapAuthProvider"
+      config:
+        enabled: true
+        mode: "search"
+        uri: "ldap://main.example.com:389"
+        base: "dc=example,dc=com"
+        # Must be true for this feature to work
+        ad_forest: true
+        # Optional. Users from this domain may login
+        # without specifying domain part
+        default_domain: main.example.com
+        # Optional. Default /
+        mxid_domain_separator: /
+        attributes:
+           # This must be set to userPrincipalName
+           # when ad_forest is true
+           uid: "userPrincipalName"
+           mail: "mail"
+           name: "givenName"
+        bind_dn: "cn=hacker,ou=svcaccts,dc=example,dc=com"
+        bind_password: "ch33kym0nk3y"
+        filter: "(objectClass=user)"
+
+With this configuration you can use logins:
+
+- `someuser/main.example.com` or `someuser`
+
+  to login as `someuser` in domain `main.example.com`
+- `someuser2/second.example.com`
+
+  to login as `someuser2` in domain `second.example.com`
+
 Troubleshooting and Debugging
 -----------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,6 @@ Let's say you have several domains in the ``example.com`` forest:
         # Optional. Users from this domain may log in without specifying the domain part
         default_domain: main.example.com
         attributes:
-           # This must be set to `userPrincipalName` when `active_directory` is true
            uid: "userPrincipalName"
            mail: "mail"
            name: "givenName"
@@ -123,8 +122,8 @@ With this configuration the user can log in with either ``main.example.com\someu
 Users of other domains in the ``example.com`` forest can log in with ``domain\login``
 or ``login/domain``.
 
-Please note that ``userPrincipalName`` or similary looking LDAP attribute in the format
-``login@domain`` must be used when ``active_directory`` option is enabled.
+Please note that ``userPrincipalName`` or a similar-looking LDAP attribute in the format
+``login@domain`` must be used when the ``active_directory`` option is enabled.
 
 Troubleshooting and Debugging
 -----------------------------

--- a/README.rst
+++ b/README.rst
@@ -86,14 +86,15 @@ Active Directory forest support
 If the ``active_directory`` flag is set to ``true``, an Active Directory forest will be
 searched for the login details.
 In this mode, the user enters their login details in one of the forms:
+
 - ``<login>/<domain>``
 - ``<domain>\<login>``
 
-Despite of entered login it will be mapped to Matrix UID ``<login>/<domain>`` (The 
-normal domain separators, ``@`` and ``\\``, cannot be used in Matrix User Identifiers, so 
-``/`` is used instead).
+In either case, this will be mapped to the Matrix UID ``<login>/<domain>`` (The 
+normal AD domain separators, ``@`` and ``\``, cannot be used in Matrix User Identifiers, so 
+``/`` is used instead.)
 
-Let's say you have several domains in example.com forest:
+Let's say you have several domains in the ``example.com`` forest:
 
 .. code:: yaml
 
@@ -106,23 +107,20 @@ Let's say you have several domains in example.com forest:
         base: "dc=example,dc=com"
         # Must be true for this feature to work
         active_directory: true
-        # Optional. Users from this domain may login
-        # without specifying domain part
+        # Optional. Users from this domain may log in without specifying the domain part
         default_domain: main.example.com
         attributes:
-           # This must be set to userPrincipalName
-           # when ad_forest is true
+           # This must be set to `userPrincipalName` when `active_directory` is true
            uid: "userPrincipalName"
            mail: "mail"
            name: "givenName"
         bind_dn: "cn=hacker,ou=svcaccts,dc=example,dc=com"
         bind_password: "ch33kym0nk3y"
-        filter: "(objectClass=user)"
 
 With this configuration the user can log in with either ``main.example.com\someuser``,
 ``someuser/main.example.com`` or ``someuser``.
 
-Users of other domains in ``example.com`` forest can log in with ``domain\login``
+Users of other domains in the ``example.com`` forest can log in with ``domain\login``
 or ``login/domain``.
 
 Troubleshooting and Debugging

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 
 class ActiveDirectoryUPNException(Exception):
-    """Raises in case Matrix ID can not be mapped to UPN"""
+    """Raised in case the user's login credentials cannot be mapped to a UPN"""
     pass
 
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -279,7 +279,7 @@ class LdapAuthProvider(object):
                     self.ldap_default_domain
                     and domain.lower() == self.ldap_default_domain.lower()
                 ):
-                    user_id = self.account_handler.get_qualified_user_id(localpart)
+                    user_id = self.account_handler.get_qualified_user_id(login)
                     if (yield self.account_handler.check_user_exists(user_id)):
                         localpart = login
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -107,7 +107,7 @@ class LdapAuthProvider(object):
         # Local part of Matrix ID which will be used in registration process
         localpart = username
         if self.ldap_active_directory:
-            (login, domain, localpart) = self.map_login_to_upn(username)
+            (login, domain, localpart) = self._map_login_to_upn(username)
             uid_value = login + "@" + domain
             default_givenName = login
 
@@ -569,7 +569,7 @@ class LdapAuthProvider(object):
             logger.warning("Error during LDAP authentication: %s", e)
             raise
 
-    def map_login_to_upn(self, username):
+    def _map_login_to_upn(self, username):
         """Maps user provided login to Active Directory UPN and
         local part of Matrix ID.
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -128,6 +128,10 @@ class LdapAuthProvider(object):
             )
 
             if self.ldap_mode == LDAPMode.SIMPLE:
+                if not password:
+                    # Password is mandatory in simple bind
+                    defer.returnValue(False)
+
                 bind_dn = "{prop}={value},{base}".format(
                     prop=self.ldap_attributes['uid'],
                     value=uid_value,

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -128,10 +128,6 @@ class LdapAuthProvider(object):
             )
 
             if self.ldap_mode == LDAPMode.SIMPLE:
-                if not password:
-                    # Password is mandatory in simple bind
-                    defer.returnValue(False)
-
                 bind_dn = "{prop}={value},{base}".format(
                     prop=self.ldap_attributes['uid'],
                     value=uid_value,

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -285,9 +285,8 @@ class LdapAuthProvider(object):
                     self.ldap_default_domain
                     and domain.lower() == self.ldap_default_domain.lower()
                 ):
-                    user_id = self.account_handler.get_qualified_user_id(login)
-                    if (yield self.account_handler.check_user_exists(user_id)):
-                        localpart = login
+                    # Users in default AD domain don't have `/domain` suffix
+                    localpart = login
 
             givenName = response["attributes"].get(
                 self.ldap_attributes["name"], [localpart]

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -280,7 +280,7 @@ class LdapAuthProvider(object):
                 self.ldap_attributes["uid"], [None]
             )
             localpart = localpart[0] if len(localpart) == 1 else None
-            if self.ldap_active_directory and localpart:
+            if self.ldap_active_directory and localpart and "@" in localpart:
                 (login, domain) = localpart.lower().rsplit("@", 1)
                 localpart = login + "/" + domain
 
@@ -394,12 +394,6 @@ class LdapAuthProvider(object):
 
         ldap_config.active_directory = config.get("active_directory", False)
         if ldap_config.active_directory:
-            if config["attributes"]["uid"].lower() != "userprincipalname":
-                raise Exception(
-                    "Only userPrincipalName is supported "
-                    "as uid property in active_directory mode"
-                )
-
             ldap_config.default_domain = config.get("default_domain", None)
 
         return ldap_config

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -110,6 +110,7 @@ class LdapAuthProvider(object):
         default_display_name = username
         # Local part of Matrix ID which will be used in registration process
         localpart = username
+
         if self.ldap_active_directory:
             (login, domain, localpart) = self._map_login_to_upn(username)
             uid_value = login + "@" + domain

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -277,6 +277,10 @@ class LdapAuthProvider(object):
                 response
             )
 
+            # Close connection
+            if hasattr(conn, "unbind"):
+                yield threads.deferToThread(conn.unbind)
+
             if not result:
                 defer.returnValue(None)
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -99,6 +99,11 @@ class LdapAuthProvider(object):
         password = login_dict['password']
         if not password:
             defer.returnValue(False)
+
+        if username.startswith("@") and ":" in username:
+            # username is of the form @foo:bar.com
+            username = username.split(":", 1)[0][1:]
+
         # Used in LDAP queries as value of ldap_attributes['uid'] attribute.
         uid_value = username
         # Default display name for the user, if a new account is registered.

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -84,7 +84,6 @@ class LdapAuthProvider(object):
         self.ldap_active_directory = config.active_directory
         if self.ldap_active_directory:
             self.ldap_default_domain = config.default_domain
-            self.ldap_separator = '/'
 
     def get_supported_login_types(self):
         return {'m.login.password': ('password',)}
@@ -272,7 +271,7 @@ class LdapAuthProvider(object):
             localpart = localpart[0] if len(localpart) == 1 else None
             if self.ldap_active_directory and localpart:
                 (login, domain) = localpart.lower().rsplit("@", 1)
-                localpart = login + self.ldap_separator + domain
+                localpart = login + "/" + domain
 
                 if (
                     self.ldap_default_domain
@@ -590,14 +589,14 @@ class LdapAuthProvider(object):
 
         if '\\' in username:
             (domain, login) = username.lower().rsplit('\\', 1)
-        elif self.ldap_separator in username:
-            (login, domain) = username.lower().rsplit(self.ldap_separator, 1)
+        elif "/" in username:
+            (login, domain) = username.lower().rsplit("/", 1)
         else:
             if not self.ldap_default_domain:
                 logger.debug(
                     'No LDAP separator %s was found in uid %s '
                     'and LDAP default domain was not configured. ',
-                    self.ldap_separator,
+                    "/",
                     self.ldap_default_domain
                 )
                 raise ActiveDirectoryUPNException()
@@ -605,7 +604,7 @@ class LdapAuthProvider(object):
         if self.ldap_default_domain and domain == self.ldap_default_domain.lower():
             localpart = login
         else:
-            localpart = login + self.ldap_separator + domain
+            localpart = login + "/" + domain
 
         return (login, domain, localpart)
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -103,7 +103,7 @@ class LdapAuthProvider(object):
         # It will differ from username in case ldap_active_directory option is enabled.
         uid_value = username
         # Used as default user name for account registration. It will be set to AD login
-        # in caseldap_active_directory option is enabled
+        # in case ldap_active_directory option is enabled
         default_givenName = username
         # Local part of Matrix UID which will be used in registration process
         localpart = username

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 
 class ActiveDirectoryUPNException(Exception):
+    """Raises in case Matrix ID can not be mapped to UPN"""
     pass
 
 
@@ -100,12 +101,10 @@ class LdapAuthProvider(object):
         if not password:
             defer.returnValue(False)
         # Used in LDAP queries as value of ldap_attributes['uid'] attribute.
-        # It will differ from username in case ldap_active_directory option is enabled.
         uid_value = username
-        # Used as default user name for account registration. It will be set to AD login
-        # in case ldap_active_directory option is enabled
-        default_givenName = username
-        # Local part of Matrix UID which will be used in registration process
+        # Default display name for the user, if a new account is registered.
+        default_display_name = username
+        # Local part of Matrix ID which will be used in registration process
         localpart = username
         if self.ldap_active_directory:
             (login, domain, localpart) = self.map_login_to_upn(username)
@@ -571,6 +570,20 @@ class LdapAuthProvider(object):
             raise
 
     def map_login_to_upn(self, username):
+        """Maps user provided login to Active Directory UPN and
+        local part of Matrix ID.
+
+        Args:
+            username (str): The user's login
+
+        Raises:
+            ActiveDirectoryUPNException: if username can not be
+                mapped to userPrincipalName
+
+        Returns:
+            Tuple[str, str, str]: a tuple of Active Directory login,
+            Active Directory domain and local part of Matrix ID.
+        """
         login = username.lower()
         domain = self.ldap_default_domain
         localpart = username

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -603,7 +603,7 @@ class LdapAuthProvider(object):
             (login, domain) = username.lower().rsplit("/", 1)
         else:
             if not self.ldap_default_domain:
-                logger.debug(
+                logger.info(
                     'No LDAP separator %s was found in uid %s '
                     'and LDAP default domain was not configured. ',
                     "/",

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -596,10 +596,9 @@ class LdapAuthProvider(object):
         else:
             if not self.ldap_default_domain:
                 logger.info(
-                    'No LDAP separator %s was found in uid %s '
-                    'and LDAP default domain was not configured. ',
-                    "/",
-                    self.ldap_default_domain
+                    'No LDAP separator "/" was found in uid "%s" '
+                    'and LDAP default domain was not configured.',
+                    username
                 )
                 raise ActiveDirectoryUPNException()
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -97,6 +97,11 @@ class LdapAuthProvider(object):
                 Canonical user ID if authentication against LDAP was successful
         """
         password = login_dict['password']
+        # According to section 5.1.2. of RFC 4513 an attempt to log in with
+        # non-empty DN and empty password is called Unauthenticated
+        # Authentication Mechanism of Simple Bind which is used to establish
+        # an anonymous authorization state and not suitable for user
+        # authentication.
         if not password:
             defer.returnValue(False)
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -97,8 +97,6 @@ class LdapAuthProvider(object):
                 Canonical user ID if authentication against LDAP was successful
         """
         password = login_dict['password']
-        if not password:
-            defer.returnValue(False)
 
         if username.startswith("@") and ":" in username:
             # username is of the form @foo:bar.com

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -108,7 +108,7 @@ class LdapAuthProvider(object):
         if self.ldap_active_directory:
             (login, domain, localpart) = self._map_login_to_upn(username)
             uid_value = login + "@" + domain
-            default_givenName = login
+            default_display_name = login
 
         try:
             tls = ldap3.Tls(validate=ssl.CERT_REQUIRED)
@@ -191,22 +191,24 @@ class LdapAuthProvider(object):
                     )
 
                     # These results will always return an array
-                    givenName = response["attributes"].get(
+                    display_name = response["attributes"].get(
                         self.ldap_attributes["name"], [localpart]
                     )
-                    givenName = (
-                        givenName[0] if len(givenName) == 1 else default_givenName
+                    display_name = (
+                        display_name[0]
+                        if len(display_name) == 1
+                        else default_display_name
                     )
 
                     mail = response["attributes"].get("mail", [None])
                     mail = mail[0] if len(mail) == 1 else None
                 else:
                     # search disabled, register account with basic information
-                    givenName = default_givenName
+                    display_name = default_display_name
                     mail = None
 
                 # Register the user
-                user_id = yield self.register_user(localpart, givenName, mail)
+                user_id = yield self.register_user(localpart, display_name, mail)
 
                 defer.returnValue(user_id)
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -97,6 +97,8 @@ class LdapAuthProvider(object):
                 Canonical user ID if authentication against LDAP was successful
         """
         password = login_dict['password']
+        if not password:
+            defer.returnValue(False)
 
         if username.startswith("@") and ":" in username:
             # username is of the form @foo:bar.com

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -112,9 +112,12 @@ class LdapAuthProvider(object):
         localpart = username
 
         if self.ldap_active_directory:
-            (login, domain, localpart) = self._map_login_to_upn(username)
-            uid_value = login + "@" + domain
-            default_display_name = login
+            try:
+                (login, domain, localpart) = self._map_login_to_upn(username)
+                uid_value = login + "@" + domain
+                default_display_name = login
+            except ActiveDirectoryUPNException:
+                defer.returnValue(False)
 
         try:
             tls = ldap3.Tls(validate=ssl.CERT_REQUIRED)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,9 +23,27 @@ dc: example
 objectClass: dcObject
 objectClass: organization
 
+dn: dc=main,dc=example,dc=org
+dc: main
+objectClass: dcObject
+objectClass: organization
+
+dn: dc=subsidiary,dc=example,dc=org
+dc: subsidiary
+objectClass: dcObject
+objectClass: organization
+
 dn: ou=people,dc=example,dc=org
 objectClass: organizationalUnit
 ou: people
+
+dn: ou=users,dc=main,dc=example,dc=org
+objectClass: organizationalUnit
+ou: users
+
+dn: ou=users,dc=subsidiary,dc=example,dc=org
+objectClass: organizationalUnit
+ou: users
 
 dn: cn=bob,ou=people,dc=example,dc=org
 cn: bob
@@ -48,6 +66,42 @@ gn: John Smith
 objectClass: person
 # password is: eekretsay
 userPassword: {SSHA}mtIQXzjeID+j1LdjduYB1kjaHPgup8UnK4ofgw==
+
+dn: cn=mainuser,ou=users,dc=main,dc=example,dc=org
+userPrincipalName: mainuser@main.example.org
+cn: mainuser
+gn: One Of
+mail: mainuser@main.example.org
+objectClass: user
+# password is: abracadabra
+userPassword: {SSHA}qLzlip9HesTLxT6qpWIawKXeKsy4L2h6
+
+dn: cn=uniqueuser,ou=users,dc=main,dc=example,dc=org
+userPrincipalName: uniqueuser@main.example.org
+cn: uniqueuser
+gn: One Of
+mail: uniqueuser@main.example.org
+objectClass: user
+# password is: nothing
+userPassword: {SSHA}jK5IJ/ozmZnEE5g6UU9WBsBBPe6LKFZz
+
+dn: cn=nonmainuser,ou=users,dc=subsidiary,dc=example,dc=org
+userPrincipalName: nonmainuser@subsidiary.example.org
+cn: nonmainuser
+gn: Someone Else
+mail: nonmainuser@subsidiary.example.org
+objectClass: user
+# password is: simsalabim
+userPassword: {SSHA}sHNj89kojBZ5DBHWDwwvzqmL0iuXn0mM
+
+dn: cn=mainuser,ou=users,dc=subsidiary,dc=example,dc=org
+userPrincipalName: mainuser@subsidiary.example.org
+cn: mainuser
+gn: One Of
+mail: mainuser@main.example.org
+objectClass: user
+# password is: changeit
+userPassword: {SSHA}AmOdJt9kOXZ2X4L89w00eKaPQN69W6yb
 
 """
 
@@ -136,3 +190,10 @@ def create_auth_provider(server, account_handler, config=None):
         })
 
     return LdapAuthProvider(config, account_handler=account_handler)
+
+
+def get_qualified_user_id(username):
+    if not username.startswith('@'):
+        return "@%s:test" % username
+
+    return username

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Yuri Konotopov <ykonotopov@gnome.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from twisted.trial import unittest
+from twisted.internet import defer
+
+from mock import Mock
+
+from . import create_ldap_server, create_auth_provider, get_qualified_user_id
+
+import logging
+logging.basicConfig()
+
+
+class AbstractLdapActiveDirectoryTestCase():
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.ldap_server = yield create_ldap_server()
+        account_handler = Mock(spec_set=["check_user_exists", "get_qualified_user_id"])
+        account_handler.check_user_exists.return_value = True
+        account_handler.get_qualified_user_id = get_qualified_user_id
+
+        self.auth_provider = create_auth_provider(
+            self.ldap_server, account_handler,
+            config=self.getConfig(),
+        )
+
+    def getConfig(self):
+        return self.getDefaultConfig()
+
+    def getDefaultConfig(self):
+        return {
+            "enabled": True,
+            "active_directory": True,
+            "uri": "ldap://localhost:%d" % self.ldap_server.listener.getHost().port,
+            "base": "dc=example,dc=org",
+            "bind_dn": "cn=jsmith,ou=people,dc=example,dc=org",
+            "bind_password": "eekretsay",
+            "attributes": {
+                "uid": "userPrincipalName",
+                "name": "gn",
+                "mail": "mail",
+            },
+        }
+
+    def tearDown(self):
+        self.ldap_server.close()
+
+
+class LdapActiveDirectoryTestCase(AbstractLdapActiveDirectoryTestCase, unittest.TestCase):
+    @defer.inlineCallbacks
+    def test_correct_pwd(self):
+        result = yield self.auth_provider.check_auth(
+            "main.example.org\\mainuser",
+            'm.login.password',
+            {"password": "abracadabra"}
+        )
+        self.assertEqual(result, "@mainuser/main.example.org:test")
+
+        result = yield self.auth_provider.check_auth(
+            "subsidiary.example.org\\nonmainuser",
+            'm.login.password',
+            {"password": "simsalabim"}
+        )
+        self.assertEqual(result, "@nonmainuser/subsidiary.example.org:test")
+
+        result = yield self.auth_provider.check_auth(
+            "subsidiary.example.org\\mainuser",
+            'm.login.password',
+            {"password": "changeit"}
+        )
+        self.assertEqual(result, "@mainuser/subsidiary.example.org:test")
+
+    @defer.inlineCallbacks
+    def test_single_email(self):
+        result = yield self.auth_provider.check_3pid_auth(
+            "email",
+            "mainuser@main.example.org",
+            "abracadabra",
+        )
+        self.assertFalse(result)
+
+    @defer.inlineCallbacks
+    def test_incorrect_pwd(self):
+        result = yield self.auth_provider.check_auth(
+            "main.example.org\\mainuser",
+            'm.login.password',
+            {"password": "bruteforce"}
+        )
+        self.assertFalse(result)
+
+        result = yield self.auth_provider.check_auth(
+            "subsidiary.example.org\\mainuser",
+            'm.login.password',
+            {"password": "abracadabra"}
+        )
+        self.assertFalse(result)
+
+    @defer.inlineCallbacks
+    def test_email_login(self):
+        result = yield self.auth_provider.check_3pid_auth(
+            "email",
+            "uniqueuser@main.example.org",
+            "nothing",
+        )
+        self.assertEqual(result, "@uniqueuser/main.example.org:test")
+
+
+class LdapActiveDirectoryDefaultDomainTestCase(
+    AbstractLdapActiveDirectoryTestCase,
+    unittest.TestCase
+):
+    def getConfig(self):
+        return dict(
+            self.getDefaultConfig(),
+            default_domain="main.example.org"
+        )
+
+    @defer.inlineCallbacks
+    def test_correct_pwd(self):
+        result = yield self.auth_provider.check_auth(
+            "mainuser",
+            'm.login.password',
+            {"password": "abracadabra"}
+        )
+        self.assertEqual(result, "@mainuser:test")
+
+        result = yield self.auth_provider.check_auth(
+            "main.example.org\\mainuser",
+            'm.login.password',
+            {"password": "abracadabra"}
+        )
+        self.assertEqual(result, "@mainuser:test")
+
+        result = yield self.auth_provider.check_auth(
+            "subsidiary.example.org\\nonmainuser",
+            'm.login.password',
+            {"password": "simsalabim"}
+        )
+        self.assertEqual(result, "@nonmainuser/subsidiary.example.org:test")
+
+        result = yield self.auth_provider.check_auth(
+            "subsidiary.example.org\\mainuser",
+            'm.login.password',
+            {"password": "changeit"}
+        )
+        self.assertEqual(result, "@mainuser/subsidiary.example.org:test")
+
+    @defer.inlineCallbacks
+    def test_incorrect_pwd(self):
+        result = yield self.auth_provider.check_auth(
+            "mainuser",
+            'm.login.password',
+            {"password": "changeit"}
+        )
+        self.assertFalse(result)
+
+        result = yield self.auth_provider.check_auth(
+            "subsidiary.example.org\\mainuser",
+            'm.login.password',
+            {"password": "abracadabra"}
+        )
+        self.assertFalse(result)
+
+    @defer.inlineCallbacks
+    def test_email_login(self):
+        result = yield self.auth_provider.check_3pid_auth(
+            "email",
+            "uniqueuser@main.example.org",
+            "nothing",
+        )
+        self.assertEqual(result, "@uniqueuser:test")

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -18,14 +18,10 @@ from twisted.internet import defer
 
 from mock import Mock
 
-from . import create_ldap_server, create_auth_provider
+from . import create_ldap_server, create_auth_provider, get_qualified_user_id
 
 import logging
 logging.basicConfig()
-
-
-def get_qualified_user_id(username):
-    return "@%s:test" % username
 
 
 class LdapSimpleTestCase(unittest.TestCase):


### PR DESCRIPTION
In AD forest samAccountName (or uid) may not be unique in the entire forest and userPrincipalName contains "@" symbol disallowed in Matrix User Identifiers.
This commit adds mxid generation logic to work around above restrictions.

Please note that ```exactly``` this commit was not yet tested by me with real AD forest, but very same implementation was tested.
Exactly this change will be tested by me next week.