### PR TITLE
Update the lowest allowed version for ldap3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     description="An LDAP3 auth provider for Synapse",
     install_requires=[
         "Twisted>=15.1.0",
-        "ldap3>=2.6",
+        "ldap3>=2.8",
         "service_identity",
     ],
     test_require=[


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-synapse-ldap3/issues/87 by bumping the lowest version allowed for ldap3 to 2.8 which includes a patch for it.