### PR TITLE
Active Directory: fetch root domain of forest from LDAP 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,8 +116,8 @@ Let's say you have several domains in the ``example.com`` forest:
         bind_dn: "cn=hacker,ou=svcaccts,dc=example,dc=com"
         bind_password: "ch33kym0nk3y"
 
-With this configuration the user can log in with either ``main.example.com\someuser``,
-``someuser/main.example.com`` or ``someuser``.
+With this configuration the user can log in with either ``main\someuser``,
+``main.example.com\someuser``, ``someuser/main.example.com`` or ``someuser``.
 
 Users of other domains in the ``example.com`` forest can log in with ``domain\login``
 or ``login/domain``.

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -84,6 +84,8 @@ class LdapAuthProvider(object):
         self.ldap_active_directory = config.active_directory
         if self.ldap_active_directory:
             self.ldap_default_domain = config.default_domain
+            # This will be set to value of Active Directory root domain of type str
+            # or to None in case of error while retrieving Active Directory root domain
             self.ldap_root_domain = False
 
     def get_supported_login_types(self):
@@ -425,7 +427,7 @@ class LdapAuthProvider(object):
         """Fetches root domain from LDAP and saves it to ``self.ldap_root_domain``
 
         Returns:
-            str: root domain of Active Directory forest
+            str: The root domain of Active Directory forest
         """
         if self.ldap_root_domain is not False:
             return self.ldap_root_domain
@@ -450,6 +452,8 @@ class LdapAuthProvider(object):
                 and "rootDomainNamingContext" in conn.server.info.other
                 and conn.server.info.other["rootDomainNamingContext"]
             ):
+                # conn.server.info.other["rootDomainNamingContext"][0]
+                # is of the form DC=example,DC=org
                 self.ldap_root_domain = ".".join(
                     [
                         dc.split("=")[1] for dc

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -454,8 +454,7 @@ class LdapAuthProvider(object):
 
         if (
             conn.server.info.other
-            and "rootDomainNamingContext" in conn.server.info.other
-            and conn.server.info.other["rootDomainNamingContext"]
+            and conn.server.info.other.get("rootDomainNamingContext")
         ):
             # conn.server.info.other["rootDomainNamingContext"][0]
             # is of the form DC=example,DC=org

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -428,8 +428,12 @@ class LdapAuthProvider(object):
     def _fetch_root_domain(self):
         """Fetches root domain from LDAP and saves it to ``self.ldap_root_domain``"""
         self.ldap_root_domain = None
-        server = self._get_server(get_info=ldap3.DSA)
 
+        if self.ldap_mode != LDAPMode.SEARCH:
+            logger.warning("Fetching root domain is supported in search mode only")
+            return
+
+        server = self._get_server(get_info=ldap3.DSA)
         result, conn = yield self._ldap_simple_bind(
             server=server,
             bind_dn=self.ldap_bind_dn,

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -125,10 +125,7 @@ class LdapAuthProvider(object):
                 defer.returnValue(False)
 
         try:
-            tls = ldap3.Tls(validate=ssl.CERT_REQUIRED)
-            server = ldap3.ServerPool(
-                [ldap3.Server(uri, get_info=None, tls=tls) for uri in self.ldap_uris],
-            )
+            server = self._get_server()
             logger.debug(
                 "Attempting LDAP connection with %s",
                 self.ldap_uris
@@ -256,9 +253,7 @@ class LdapAuthProvider(object):
 
         # Talk to LDAP and check if this email/password combo is correct
         try:
-            server = ldap3.ServerPool(
-                [ldap3.Server(uri, get_info=None) for uri in self.ldap_uris],
-            )
+            server = self._get_server()
             logger.debug(
                 "Attempting LDAP connection with %s",
                 self.ldap_uris
@@ -406,6 +401,18 @@ class LdapAuthProvider(object):
             ldap_config.default_domain = config.get("default_domain", None)
 
         return ldap_config
+
+    def _get_server(self):
+        return ldap3.ServerPool(
+            [
+                ldap3.Server(
+                    uri,
+                    get_info=None,
+                    tls=ldap3.Tls(validate=ssl.CERT_REQUIRED)
+                )
+                for uri in self.ldap_uris
+            ],
+        )
 
     @defer.inlineCallbacks
     def _ldap_simple_bind(self, server, bind_dn, password):

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -448,26 +448,27 @@ class LdapAuthProvider(object):
             password=self.ldap_bind_password,
         )
 
-        if result:
-            if (
-                conn.server.info.other
-                and "rootDomainNamingContext" in conn.server.info.other
-                and conn.server.info.other["rootDomainNamingContext"]
-            ):
-                # conn.server.info.other["rootDomainNamingContext"][0]
-                # is of the form DC=example,DC=org
-                self.ldap_root_domain = ".".join(
-                    [
-                        dc.split("=")[1] for dc
-                        in conn.server.info.other["rootDomainNamingContext"][0].split(",")
-                        if "=" in dc
-                    ]
-                )
-                logger.info('Obtained root domain "%s"', self.ldap_root_domain)
-
-            await threads.deferToThread(conn.unbind)
-        else:
+        if not result:
             logger.warning("Unable to get root domain")
+            return self.ldap_root_domain
+
+        if (
+            conn.server.info.other
+            and "rootDomainNamingContext" in conn.server.info.other
+            and conn.server.info.other["rootDomainNamingContext"]
+        ):
+            # conn.server.info.other["rootDomainNamingContext"][0]
+            # is of the form DC=example,DC=org
+            self.ldap_root_domain = ".".join(
+                [
+                    dc.split("=")[1] for dc
+                    in conn.server.info.other["rootDomainNamingContext"][0].split(",")
+                    if "=" in dc
+                ]
+            )
+            logger.info('Obtained root domain "%s"', self.ldap_root_domain)
+
+        await threads.deferToThread(conn.unbind)
 
         return self.ldap_root_domain
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -464,11 +464,10 @@ class LdapAuthProvider(object):
                     ]
                 )
                 logger.info('Obtained root domain "%s"', self.ldap_root_domain)
+
+            await threads.deferToThread(conn.unbind)
         else:
             logger.warning("Unable to get root domain")
-
-        if hasattr(conn, "unbind"):
-            await threads.deferToThread(conn.unbind)
 
         return self.ldap_root_domain
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -63,6 +63,7 @@ class LDAPMode(object):
 
 class LdapAuthProvider(object):
     __version__ = "0.1"
+    _ldap_tls = ldap3.Tls(validate=ssl.CERT_REQUIRED)
 
     def __init__(self, config, account_handler):
         self.account_handler = account_handler
@@ -419,7 +420,7 @@ class LdapAuthProvider(object):
                 ldap3.Server(
                     uri,
                     get_info=get_info,
-                    tls=ldap3.Tls(validate=ssl.CERT_REQUIRED)
+                    tls=self._ldap_tls
                 )
                 for uri in self.ldap_uris
             ],

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from twisted.internet import threads
 
 
@@ -402,11 +404,11 @@ class LdapAuthProvider(object):
 
         return ldap_config
 
-    def _get_server(self, get_info=None):
+    def _get_server(self, get_info: Optional[str] = None) -> ldap3.ServerPool:
         """Constructs ServerPool from configured LDAP URIs
 
         Args:
-            get_info ([str], optional): specifies if the server schema and server
+            get_info (str, optional): specifies if the server schema and server
             specific info must be read. Defaults to None.
 
         Returns:

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -435,7 +435,7 @@ class LdapAuthProvider(object):
             return self.ldap_root_domain
 
         if self.ldap_mode != LDAPMode.SEARCH:
-            logger.warning("Fetching root domain is supported in search mode only")
+            logger.info("Fetching root domain is supported in search mode only")
             self.ldap_root_domain = None
             return self.ldap_root_domain
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -412,7 +412,7 @@ class LdapAuthProvider(object):
             specific info must be read. Defaults to None.
 
         Returns:
-            [ServerPool]: servers groupped to ServerPool
+            Servers grouped in a ServerPool
         """
         return ldap3.ServerPool(
             [
@@ -429,7 +429,7 @@ class LdapAuthProvider(object):
         """Fetches root domain from LDAP and saves it to ``self.ldap_root_domain``
 
         Returns:
-            str: The root domain of Active Directory forest
+            The root domain of Active Directory forest
         """
         if self.ldap_root_domain is not None:
             return self.ldap_root_domain

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -468,6 +468,12 @@ class LdapAuthProvider(object):
             )
             logger.info('Obtained root domain "%s"', self.ldap_root_domain)
 
+        if not self.ldap_root_domain:
+            logger.warning(
+                "No valid `rootDomainNamingContext` attribute was found in the RootDSE. "
+                "Logging in using short domain name will be unavailable."
+            )
+
         await threads.deferToThread(conn.unbind)
 
         return self.ldap_root_domain

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -449,7 +449,7 @@ class LdapAuthProvider(object):
         )
 
         if not result:
-            logger.warning("Unable to get root domain")
+            logger.warning("Unable to get root domain due to failed LDAP bind")
             return self.ldap_root_domain
 
         if (

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -117,10 +117,10 @@ async def _create_db():
 
 
 class _LDAPServerFactory(ServerFactory):
-    def __init__(self, root, ldap_server=LDAPServer):
+    def __init__(self, root, ldap_server_type=LDAPServer):
         self.root = root
-        if ldap_server:
-            self.protocol = ldap_server
+        if ldap_server_type:
+            self.protocol = ldap_server_type
 
     def buildProtocol(self, addr):
         proto = self.protocol()
@@ -158,11 +158,11 @@ registerAdapter(
 )
 
 
-async def create_ldap_server(ldap_server: Optional[LDAPServer] = None):
+async def create_ldap_server(ldap_server_type: Optional[LDAPServer] = None):
     "Returns a context manager that represents the LDAP server."
 
     db = await _create_db()
-    factory = _LDAPServerFactory(db, ldap_server)
+    factory = _LDAPServerFactory(db, ldap_server_type)
     factory.debug = True
 
     # We just pick an arbitrary port to listen on.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 from asyncio.futures import Future
-from typing import Any, Awaitable, Optional
+from typing import Any, Awaitable, Type
 
 from twisted.internet.endpoints import serverFromString
 from twisted.internet.protocol import ServerFactory
@@ -117,7 +117,7 @@ async def _create_db():
 
 
 class _LDAPServerFactory(ServerFactory):
-    def __init__(self, root, ldap_server_type=LDAPServer):
+    def __init__(self, root, ldap_server_type: Type[LDAPServer] = LDAPServer):
         self.root = root
         if ldap_server_type:
             self.protocol = ldap_server_type
@@ -158,7 +158,7 @@ registerAdapter(
 )
 
 
-async def create_ldap_server(ldap_server_type: Optional[LDAPServer] = None):
+async def create_ldap_server(ldap_server_type: Type[LDAPServer] = None):
     "Returns a context manager that represents the LDAP server."
 
     db = await _create_db()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -120,8 +120,10 @@ async def _create_db():
 
 
 class _ActiveDirectoryLDAPServer(LDAPServer):
-    """LDAPServer implementation with Active Directory
-    specific attribute rootDomainNamingContext"""
+    """Extends LDAPServer to return AD-specific attributes
+
+    Includes `rootDomainNamingContext` in bind responses.
+    """
     def getRootDSE(self, request, reply):
         root = interfaces.IConnectedLDAPEntry(self.factory)
         reply(pureldap.LDAPSearchResultEntry(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -120,6 +120,8 @@ async def _create_db():
 
 
 class _ActiveDirectoryLDAPServer(LDAPServer):
+    """LDAPServer implementation with Active Directory
+    specific attribute rootDomainNamingContext"""
     def getRootDSE(self, request, reply):
         root = interfaces.IConnectedLDAPEntry(self.factory)
         reply(pureldap.LDAPSearchResultEntry(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -119,8 +119,7 @@ async def _create_db():
 class _LDAPServerFactory(ServerFactory):
     def __init__(self, root, ldap_server_type: Type[LDAPServer] = LDAPServer):
         self.root = root
-        if ldap_server_type:
-            self.protocol = ldap_server_type
+        self.protocol = ldap_server_type
 
     def buildProtocol(self, addr):
         proto = self.protocol()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -117,9 +117,7 @@ async def _create_db():
 
 
 class _LDAPServerFactory(ServerFactory):
-    protocol = LDAPServer
-
-    def __init__(self, root, ldap_server):
+    def __init__(self, root, ldap_server=LDAPServer):
         self.root = root
         if ldap_server:
             self.protocol = ldap_server

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -158,7 +158,7 @@ registerAdapter(
 )
 
 
-async def create_ldap_server(ldap_server_type: Type[LDAPServer] = None):
+async def create_ldap_server(ldap_server_type: Type[LDAPServer] = LDAPServer):
     "Returns a context manager that represents the LDAP server."
 
     db = await _create_db()

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -70,6 +70,13 @@ class LdapActiveDirectoryTestCase(AbstractLdapActiveDirectoryTestCase, unittest.
         self.assertEqual(result, "@mainuser/main.example.org:test")
 
         result = yield self.auth_provider.check_auth(
+            "main\\mainuser",
+            'm.login.password',
+            {"password": "abracadabra"}
+        )
+        self.assertEqual(result, "@mainuser/main.example.org:test")
+
+        result = yield self.auth_provider.check_auth(
             "subsidiary.example.org\\nonmainuser",
             'm.login.password',
             {"password": "simsalabim"}
@@ -77,7 +84,21 @@ class LdapActiveDirectoryTestCase(AbstractLdapActiveDirectoryTestCase, unittest.
         self.assertEqual(result, "@nonmainuser/subsidiary.example.org:test")
 
         result = yield self.auth_provider.check_auth(
+            "subsidiary\\nonmainuser",
+            'm.login.password',
+            {"password": "simsalabim"}
+        )
+        self.assertEqual(result, "@nonmainuser/subsidiary.example.org:test")
+
+        result = yield self.auth_provider.check_auth(
             "subsidiary.example.org\\mainuser",
+            'm.login.password',
+            {"password": "changeit"}
+        )
+        self.assertEqual(result, "@mainuser/subsidiary.example.org:test")
+
+        result = yield self.auth_provider.check_auth(
+            "subsidiary\\mainuser",
             'm.login.password',
             {"password": "changeit"}
         )

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -12,6 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from ldaptor import interfaces
+from ldaptor.protocols import pureldap
+from ldaptor.protocols.ldap import ldaperrors
+from ldaptor.protocols.ldap.ldapserver import LDAPServer
+
 from twisted.internet.defer import ensureDeferred
 from twisted.trial import unittest
 from twisted.internet import defer
@@ -29,10 +34,30 @@ import logging
 logging.basicConfig()
 
 
+class _ActiveDirectoryLDAPServer(LDAPServer):
+    """Extends LDAPServer to return AD-specific attributes
+
+    Includes `rootDomainNamingContext` in bind responses.
+    """
+    def getRootDSE(self, request, reply):
+        root = interfaces.IConnectedLDAPEntry(self.factory)
+        reply(pureldap.LDAPSearchResultEntry(
+            objectName='',
+            attributes=[('supportedLDAPVersion', ['3']),
+                        ('namingContexts', [root.dn.getText()]),
+                        ('supportedExtension', [
+                            pureldap.LDAPPasswordModifyRequest.oid, ]),
+                        ('rootDomainNamingContext', ['DC=example,DC=org']), ], ))
+        return pureldap.LDAPSearchResultDone(
+            resultCode=ldaperrors.Success.resultCode)
+
+
 class AbstractLdapActiveDirectoryTestCase():
     @defer.inlineCallbacks
     def setUp(self):
-        self.ldap_server = yield ensureDeferred(create_ldap_server())
+        self.ldap_server = yield ensureDeferred(
+            create_ldap_server(_ActiveDirectoryLDAPServer)
+        )
         account_handler = Mock(spec_set=["check_user_exists", "get_qualified_user_id"])
         account_handler.check_user_exists.return_value = make_awaitable(True)
         account_handler.get_qualified_user_id = get_qualified_user_id


### PR DESCRIPTION
This change allows to use short domain name in login field.  
As part of this PR ssl certificate validation in ```check_3pid_auth``` is fixed also.