### PR TITLE
Module template retrofit: Update tox.ini with result of templating (some old jobs are preserved)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,8 @@
 check_untyped_defs = True
 scripts_are_modules = True
 
+# TODO The tests currently do not pass Mypy.
+# Don't forget to update tox.ini when they do!
 files =
     ldap_auth_provider.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
-envlist = packaging, pep8, py35, py36, py37, py38
-isolated_build = True
+envlist = packaging, pep8, py35, py36, py37, py38, check_codestyle, check_types
+
+# required for PEP 517 (pyproject.toml-style) builds
+isolated_build = true
 
 [testenv]
 deps =
@@ -23,6 +25,7 @@ commands =
     check-manifest
 
 [testenv:pep8]
+# Temporary, for backwards compatibility with the BuildKite pipelines
 skip_install = True
 basepython = python3.5
 deps =
@@ -40,3 +43,19 @@ deps =
 commands =
     coverage xml
     codecov -X gcov
+
+[testenv:check_codestyle]
+
+extras = dev
+
+commands =
+  flake8 ldap_auth_provider.py tests
+  black --check --diff ldap_auth_provider.py tests
+  isort --check-only --diff ldap_auth_provider.py tests
+
+[testenv:check_types]
+
+extras = dev
+
+commands =
+  mypy ldap_auth_provider.py tests

--- a/tox.ini
+++ b/tox.ini
@@ -58,4 +58,6 @@ commands =
 extras = dev
 
 commands =
-  mypy ldap_auth_provider.py tests
+  # mypy ldap_auth_provider.py tests
+  # tests currently do not pass
+  mypy ldap_auth_provider.py


### PR DESCRIPTION
This PR preserves the Tox jobs needed for BK whilst also creating those that are used by the GH Actions following shortly.