### PR TITLE
Add support for providing tls_options

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -50,6 +50,7 @@ class _LdapConfig:
     uri: Union[str, List[str]]
     start_tls: bool
     validate_cert: bool
+    tls_options: Dict[str, Any]
     base: str
     attributes: Dict[str, str]
     bind_dn: Optional[str] = None
@@ -69,9 +70,16 @@ class LdapAuthProvider:
 
         self.ldap_mode = config.mode
         self.ldap_uris = [config.uri] if isinstance(config.uri, str) else config.uri
-        self.ldap_tls = ldap3.Tls(
-            validate=ssl.CERT_REQUIRED if config.validate_cert else ssl.CERT_NONE
-        )
+        if config.tls_options:
+            if config.validate_cert:
+                logger.warning("Config key validate_cert is not used when tls_options is specified")
+            self.ldap_tls = ldap3.Tls(
+                **tls_options
+            )
+        else:
+            self.ldap_tls = ldap3.Tls(
+                validate=ssl.CERT_REQUIRED if config.validate_cert else ssl.CERT_NONE
+            )
         self.ldap_start_tls = config.start_tls
         self.ldap_base = config.base
         self.ldap_attributes = config.attributes


### PR DESCRIPTION
It's a bit unfortunate that this came after #136. We basically need to expose a couple of options to provide our own cert + passphrase. Rather than providing a new key for each option that comes along, it felt better to simply expose a tls_options config option.