### PR TITLE
Normalize username before interacting with Synapse 

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -23,7 +23,7 @@ import ldap3.core.exceptions
 import synapse
 from pkg_resources import parse_version
 from synapse.module_api import ModuleApi
-from synapse.types import JsonDict, map_username_to_mxid_localpart
+from synapse.types import JsonDict
 from twisted.internet import threads
 
 __version__ = "0.2.0"
@@ -182,11 +182,8 @@ class LdapAuthProvider:
                 )
                 return None
 
-            # normalize localpart for use with synapse
-            normalized_localpart = map_username_to_mxid_localpart(localpart)
-
             # Get full user id from localpart
-            user_id = self.account_handler.get_qualified_user_id(normalized_localpart)
+            user_id = self.account_handler.get_qualified_user_id(localpart.lower())
 
             # check if user with user_id exists
             if await self.account_handler.check_user_exists(user_id):
@@ -226,7 +223,7 @@ class LdapAuthProvider:
                     mail = None
 
                 # Register the user
-                user_id = await self.register_user(normalized_localpart, display_name, mail)
+                user_id = await self.register_user(localpart.lower(), display_name, mail)
 
                 return user_id
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -223,7 +223,9 @@ class LdapAuthProvider:
                     mail = None
 
                 # Register the user
-                user_id = await self.register_user(localpart.lower(), display_name, mail)
+                user_id = await self.register_user(
+                    localpart.lower(), display_name, mail
+                )
 
                 return user_id
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -183,10 +183,10 @@ class LdapAuthProvider:
                 return None
 
             # normalize localpart for use with synapse
-            localpart = synapse.types.map_username_to_mxid_localpart(localpart)
+            normalized_localpart = synapse.types.map_username_to_mxid_localpart(localpart)
 
             # Get full user id from localpart
-            user_id = self.account_handler.get_qualified_user_id(localpart)
+            user_id = self.account_handler.get_qualified_user_id(normalized_localpart)
 
             # check if user with user_id exists
             if await self.account_handler.check_user_exists(user_id):
@@ -226,7 +226,7 @@ class LdapAuthProvider:
                     mail = None
 
                 # Register the user
-                user_id = await self.register_user(localpart, display_name, mail)
+                user_id = await self.register_user(normalized_localpart, display_name, mail)
 
                 return user_id
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -183,7 +183,7 @@ class LdapAuthProvider:
                 return None
 
             # normalize localpart for use with synapse
-            normalized_localpart = synapse.types.map_username_to_mxid_localpart(localpart)
+            normalized_localpart = map_username_to_mxid_localpart(localpart)
 
             # Get full user id from localpart
             user_id = self.account_handler.get_qualified_user_id(normalized_localpart)

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -133,6 +133,8 @@ class LdapAuthProvider:
             except ActiveDirectoryUPNException:
                 return None
 
+        localpart = localpart.lower()
+
         try:
             server = self._get_server()
             logger.debug("Attempting LDAP connection with %s", self.ldap_uris)
@@ -183,7 +185,7 @@ class LdapAuthProvider:
                 return None
 
             # Get full user id from localpart
-            user_id = self.account_handler.get_qualified_user_id(localpart.lower())
+            user_id = self.account_handler.get_qualified_user_id(localpart)
 
             # check if user with user_id exists
             if await self.account_handler.check_user_exists(user_id):
@@ -223,9 +225,7 @@ class LdapAuthProvider:
                     mail = None
 
                 # Register the user
-                user_id = await self.register_user(
-                    localpart.lower(), display_name, mail
-                )
+                user_id = await self.register_user(localpart, display_name, mail)
 
                 return user_id
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -23,7 +23,7 @@ import ldap3.core.exceptions
 import synapse
 from pkg_resources import parse_version
 from synapse.module_api import ModuleApi
-from synapse.types import JsonDict
+from synapse.types import JsonDict, map_username_to_mxid_localpart
 from twisted.internet import threads
 
 __version__ = "0.2.0"
@@ -181,6 +181,9 @@ class LdapAuthProvider:
                     "Authentication method yielded no LDAP connection, aborting!"
                 )
                 return None
+
+            # normalize localpart for use with synapse
+            localpart = synapse.types.map_username_to_mxid_localpart(localpart)
 
             # Get full user id from localpart
             user_id = self.account_handler.get_qualified_user_id(localpart)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -95,6 +95,15 @@ class LdapSimpleTestCase(unittest.TestCase):
         )
         self.assertFalse(result)
 
+    @defer.inlineCallbacks
+    def test_uppercase_username(self):
+        result = yield defer.ensureDeferred(
+            self.auth_provider.check_auth(
+                "BOB", "m.login.password", {"password": "secret"}
+            )
+        )
+        self.assertEqual(result, "@bob:test")
+
 
 class LdapSearchTestCase(unittest.TestCase):
     @defer.inlineCallbacks


### PR DESCRIPTION
Currently the LDAP module does not check if a username is compatible with the matrix id grammar before attempting to register or login with it in Synapse, resulting in failure. This PR runs all usernames through a normalization function after successfully authenticating against an LDAP server so that they are compatible with Synapse. I added a rather anemic test that only tests one of two login scenarios as the other path (registering with synapse) seems pretty difficult to meaningfully test. Fixes #72.