### PR TITLE
Bump version of black to 22.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ dev =
   types-setuptools
 
   # for linting
-  black == 21.9b0
+  black == 22.3.0
   flake8 == 4.0.1
   isort == 5.9.3
 


### PR DESCRIPTION
This is in line with what synapse currently uses, and fixes a CI import error. 