### PR TITLE
Fix a regression wherein users with historical usernames containing capital letters can't log in 

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -186,12 +186,12 @@ class LdapAuthProvider:
             user_id = self.account_handler.get_qualified_user_id(localpart)
 
             # check if user with user_id exists
-            cannonical_user_id = await self.account_handler.check_user_exists(user_id)
-            if cannonical_user_id:
+            canonical_user_id = await self.account_handler.check_user_exists(user_id)
+            if canonical_user_id:
                 # exists, authentication complete
                 if hasattr(conn, "unbind"):
                     await threads.deferToThread(conn.unbind)
-                return cannonical_user_id
+                return canonical_user_id
 
             else:
                 # does not exist, register

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -40,7 +40,9 @@ class LdapSimpleTestCase(unittest.TestCase):
                 "register_password_auth_provider_callbacks",
             ]
         )
-        module_api.check_user_exists.return_value = make_awaitable("@bob:test")
+        module_api.check_user_exists.side_effect = lambda user_id: make_awaitable(
+            user_id
+        )
         module_api.get_qualified_user_id = get_qualified_user_id
 
         self.auth_provider = create_auth_provider(
@@ -107,7 +109,9 @@ class LdapSearchTestCase(unittest.TestCase):
                 "register_password_auth_provider_callbacks",
             ]
         )
-        module_api.check_user_exists.return_value = make_awaitable("@bob:test")
+        module_api.check_user_exists.side_effect = lambda user_id: make_awaitable(
+            user_id
+        )
         module_api.get_qualified_user_id = get_qualified_user_id
 
         self.auth_provider = create_auth_provider(

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -40,7 +40,7 @@ class LdapSimpleTestCase(unittest.TestCase):
                 "register_password_auth_provider_callbacks",
             ]
         )
-        module_api.check_user_exists.return_value = make_awaitable(True)
+        module_api.check_user_exists.return_value = make_awaitable("@bob:test")
         module_api.get_qualified_user_id = get_qualified_user_id
 
         self.auth_provider = create_auth_provider(
@@ -95,15 +95,6 @@ class LdapSimpleTestCase(unittest.TestCase):
         )
         self.assertFalse(result)
 
-    @defer.inlineCallbacks
-    def test_uppercase_username(self):
-        result = yield defer.ensureDeferred(
-            self.auth_provider.check_auth(
-                "BOB", "m.login.password", {"password": "secret"}
-            )
-        )
-        self.assertEqual(result, "@bob:test")
-
 
 class LdapSearchTestCase(unittest.TestCase):
     @defer.inlineCallbacks
@@ -116,7 +107,7 @@ class LdapSearchTestCase(unittest.TestCase):
                 "register_password_auth_provider_callbacks",
             ]
         )
-        module_api.check_user_exists.return_value = make_awaitable(True)
+        module_api.check_user_exists.return_value = make_awaitable("@bob:test")
         module_api.get_qualified_user_id = get_qualified_user_id
 
         self.auth_provider = create_auth_provider(


### PR DESCRIPTION
Introduced in #163, which attempted to allow users to authenticate with LDAP usernames containing capital letters by lowercasing the username before interacting with Synapse. This then broke logins for users with historical usernames containing uppercase letters, as the login process created an access token based on the lowercased username, which didn't actually exist. This PR fixes this by only lowercasing the username if synapse is going to create a new account for the user, and using the value returned by `check_user_exists` as the canonical username. 