### PR TITLE
Allow to read bind_password from a file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,20 @@ in search mode is provided below:
         #  local_private_key_file: bar.pem
         #  local_private_key_password: secret
 
+Alternatively you can also put the ``bind_password`` of your service user into its
+own file to not leak secrets into your configuration:
+
+.. code:: yaml
+
+   modules:
+    - module: "ldap_auth_provider.LdapAuthProviderModule"
+      config:
+        enabled: true
+        # all the other options you need
+        bind_password_file: "/var/secrets/synapse-ldap-bind-password"
+
+Please note that every trailing ``\n`` in the password file will be stripped automatically.
+
 Active Directory forest support
 -------------------------------
 

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -388,12 +388,19 @@ class LdapAuthProvider:
                 config,
                 [
                     "bind_dn",
-                    "bind_password",
                 ],
             )
 
             ldap_config.bind_dn = config["bind_dn"]
-            ldap_config.bind_password = config["bind_password"]
+            if "bind_password" in config:
+                ldap_config.bind_password = config["bind_password"]
+            elif "bind_password_file" in config:
+                with open(config["bind_password_file"], "r") as f:
+                    ldap_config.bind_password = f.read().rstrip("\n")
+            else:
+                raise ValueError(
+                    "Either bind_password or bind_password_file must be set!"
+                )
             ldap_config.filter = config.get("filter", None)
 
         # verify attribute lookup


### PR DESCRIPTION
That way you don't have to leak your bind password into your config.
Useful for e.g. NixOS where config is stored in a world-readable
location.