### PR TITLE
Add numeric username support

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -123,7 +123,10 @@ class LdapAuthProvider:
         # Default display name for the user, if a new account is registered.
         default_display_name = username
         # Local part of Matrix ID which will be used in registration process
-        localpart = username
+        if username.isnumeric():
+            localpart = f"U{username}"
+        else:
+            localpart = username
 
         if self.ldap_active_directory:
             try:


### PR DESCRIPTION
Synapse does not accept numeric usernames since they are reserved for the guest account. If a unique LDAP attribute is chosen while signing in, Synapse returns an error and LDAP module says invalid username or password. This patch handles numeric only usernames by adding an uppercase "U" in the beginning of the numeric username (returned from LDAP uid attribute).

This pull request is related with the issue https://github.com/matrix-org/matrix-synapse-ldap3/issues/55.
