### PR TITLE
Use configured "mail" attribute when fetching mail addresses from LDAP

### DIFF
--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -216,7 +216,7 @@ class LdapAuthProvider:
                         else default_display_name
                     )
 
-                    mail = response["attributes"].get("mail", [None])
+                    mail = response["attributes"].get(self.ldap_attributes["mail"], [None])
                     mail = mail[0] if len(mail) == 1 else None
                 else:
                     # search disabled, register account with basic information

--- a/ldap_auth_provider.py
+++ b/ldap_auth_provider.py
@@ -216,7 +216,9 @@ class LdapAuthProvider:
                         else default_display_name
                     )
 
-                    mail = response["attributes"].get(self.ldap_attributes["mail"], [None])
+                    mail = response["attributes"].get(
+                        self.ldap_attributes["mail"], [None]
+                    )
                     mail = mail[0] if len(mail) == 1 else None
                 else:
                     # search disabled, register account with basic information


### PR DESCRIPTION
use the attribute from config to get mail address from ldap object instead of hard coded "mail".
Signed-off-by: Bernhard Lichtinger <bernhard.lichtinger@lrz.de>