### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# This file is adapted from the same file in element-hq/synapse:
+# https://github.com/element-hq/synapse/blob/2e9b8202f0a1a8ceba9f02bb5ec227498d51dcbd/.github/dependabot.yml
+version: 2
+# As dependabot is currently only run on a weekly basis, we raise the
+# open-pull-requests-limit to 10 (from the default of 5) to better ensure we
+# don't continuously grow a backlog of updates.
+updates:
+  - # "pip" is the correct setting for poetry, per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+    package-ecosystem: "pip"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    # Group patch updates to packages together into a single PR, as they rarely
+    # if ever contain breaking changes that need to be reviewed separately.
+    # 
+    # Less PRs means a streamlined review process.
+    #
+    # Python packages follow semantic versioning, and tend to only introduce
+    # breaking changes in major version bumps. Thus, we'll group minor and patch
+    # versions together.
+    groups:
+      minor-and-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Prevent pulling packages that were recently updated to help mitigate
+    # supply chain attacks. 14 days was taken from the recommendation at
+    # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+    # where the author noted that 9/10 attacks would have been mitigated by a
+    # two week cooldown.
+    #
+    # The cooldown only applies to general updates; security updates will still
+    # be pulled in as soon as possible.
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    # Similarly for GitHub Actions, breaking changes are typically only introduced in major
+    # package bumps.
+    groups:
+      minor-and-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,38 +5,7 @@ version: 2
 # open-pull-requests-limit to 10 (from the default of 5) to better ensure we
 # don't continuously grow a backlog of updates.
 updates:
-  - # "pip" is the correct setting for poetry, per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
-    package-ecosystem: "pip"
-    directory: "/"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "weekly"
-    # Group patch updates to packages together into a single PR, as they rarely
-    # if ever contain breaking changes that need to be reviewed separately.
-    # 
-    # Less PRs means a streamlined review process.
-    #
-    # Python packages follow semantic versioning, and tend to only introduce
-    # breaking changes in major version bumps. Thus, we'll group minor and patch
-    # versions together.
-    groups:
-      minor-and-patches:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    # Prevent pulling packages that were recently updated to help mitigate
-    # supply chain attacks. 14 days was taken from the recommendation at
-    # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
-    # where the author noted that 9/10 attacks would have been mitigated by a
-    # two week cooldown.
-    #
-    # The cooldown only applies to general updates; security updates will still
-    # be pulled in as soon as possible.
-    cooldown:
-      default-days: 14
+  # Note: there locked python dependencies in this repo (yet!)
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Even though this repo has recently been put into maintenance mode, part of that is keeping the dependencies up to date.

Adding this file tells dependabot to send update PRs weekly for this repo.

**https://github.com/matrix-org/matrix-synapse-ldap3/pull/206 should be merged before this PR.**