### PR TITLE
GitHub Actions hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.x"
@@ -21,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.x"
@@ -37,6 +41,8 @@ jobs:
         python_version: [ "3.10", "3.x" ]
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: ${{ matrix.python_version }}
@@ -48,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: ${{ matrix.python_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     name: Check code style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.x"
       - run: python -m pip install tox
@@ -20,8 +20,8 @@ jobs:
     name: Check types with Mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.x"
       - run: python -m pip install tox
@@ -36,8 +36,8 @@ jobs:
         # and the newest stable.
         python_version: [ "3.10", "3.x" ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: ${{ matrix.python_version }}
       - run: python -m pip install tox
@@ -47,8 +47,8 @@ jobs:
     name: Check Packaging
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: ${{ matrix.python_version }}
       - run: python -m pip install tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,13 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions: {}
+
 jobs:
   check-code-style:
+    permissions:
+      # To check out the repo.
+      contents: read
     name: Check code style
     runs-on: ubuntu-latest
     steps:
@@ -19,6 +24,9 @@ jobs:
       - run: tox -e check_codestyle
 
   check-types:
+    permissions:
+      # To check out the repo.
+      contents: read
     name: Check types with Mypy
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +40,10 @@ jobs:
       - run: tox -e check_types
 
   unit-tests:
+    permissions:
+      # To check out the repo.
+      contents: read
+
     name: Unit tests
     runs-on: ubuntu-latest
     strategy:
@@ -50,6 +62,9 @@ jobs:
       - run: tox -e py
 
   packaging:
+    permissions:
+      # To check out the repo.
+      contents: read
     name: Check Packaging
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [ opened ]
 
+# No GITHUB_TOKEN permissions are needed here, as we supply our own token below
+# to complete the GraphQL call.
+permissions: {}
+
 jobs:
   add_new_issues:
     name: Add new issues to the triage board

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -9,7 +9,7 @@ jobs:
     name: Add new issues to the triage board
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/graphql-action@v2.x
+      - uses: octokit/graphql-action@f7836e89a7e5bac63911bbe9653c21147b3d9bc3 # v2.3.3
         id: add_to_project
         with:
           headers: '{"GraphQL-Features": "projects_next_graphql"}'

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Set status
         env:
           GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+          STEPS_ADD_PROJECT_OUTPUTS_ITEMID: ${{ steps.add_project.outputs.itemId }}
         run: |
           gh api graphql -f query='
           mutation(
@@ -41,4 +42,4 @@ jobs:
                 id
               }
             }
-          }' -f project="PVT_kwDOAIB0Bs4AFDdZ" -f item=${{ steps.add_project.outputs.itemId }} -f fieldid="PVTSSF_lADOAIB0Bs4AFDdZzgC6ZA4" -f columnid=ba22e43c --silent
+          }' -f project="PVT_kwDOAIB0Bs4AFDdZ" -f item=${STEPS_ADD_PROJECT_OUTPUTS_ITEMID} -f fieldid="PVTSSF_lADOAIB0Bs4AFDdZzgC6ZA4" -f columnid=ba22e43c --silent

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -11,7 +11,7 @@ jobs:
     if: >
       contains(github.event.issue.labels.*.name, 'X-Needs-Info')
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@27022a19346d0433f2b9859dd2b69d38f4277808 # main
         id: add_project
         with:
           project-url: "https://github.com/orgs/matrix-org/projects/67"

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [ labeled ]
 
+# No GITHUB_TOKEN permissions are needed here, as we supply our own token below
+# to complete the GraphQL calls and `gh` invocations.
+permissions: {}
+
 jobs:
   move_needs_info:
     name: Move X-Needs-Info on the triage board

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+# Taken from https://github.com/zizmorcore/zizmor-action's README.
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
Hardens our GitHub Actions using `zizmor`, along with [our internal GHA hardening guidelines](https://docs.google.com/document/d/1nR8oCHyovy-YNrM9sJdEz3yj6EZdjdRNnsadVV_b6cY/edit?tab=t.0).

Ideally we'd merged this before https://github.com/matrix-org/matrix-synapse-ldap3/pull/206, so dependabot updates with hashes instead of just tags.

Recommended to review commit-by-commit.